### PR TITLE
Allow entering a full URL for the Vision and Text model hosts. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,27 @@ To install the "Ollama Vision" integration in Home Assistant, follow these steps
 After restarting Home Assistant, go to Settings → Devices & Services.
 
  1. Click + Add Integration.
- 2. Search for “Ollama Vision” and select it.
- 3. You’ll be prompted to configure:
+ 2. Search for "Ollama Vision" and select it.
+ 3. You'll be prompted to configure:
 
  - **Name**: A name for this Ollama Vision instance
- - **Vision Host**: Hostname/IP for your Ollama server running the vision-enabled model
- - **Vision Port**: Port for the vision server (default: 11434)
+ - **Vision Host**: Host address for your Ollama server running the vision-enabled model. Accepts:
+   - Full URL with path: `http://server.example.com/subpath` or `https://server.example.com/subpath`
+   - Hostname with port: `192.168.1.1:11434`
+   - Hostname only: `192.168.1.1` (defaults to port 11434)
  - **Vision Model**: The vision-capable model name (default: moondream)
  - **Vision Model Keep-Alive**: Keep this model loaded in memory (-1 for indefinite)
  - **Enable Text Model**: Toggle a separate text model for enhanced descriptions
- - **Text Model Host**: Hostname/IP for the optional text-model server
- - **Text Model Port**: Port for the text-model server (default: 11434)
+ - **Text Model Host**: Host address for the optional text-model server. Accepts the same formats as Vision Host:
+   - Full URL with path: `http://server.example.com/subpath` or `https://server.example.com/subpath`
+   - Hostname with port: `192.168.1.1:11434`
+   - Hostname only: `192.168.1.1` (defaults to port 11434)
  - **Text Model**: The text model name (default: llama3.1)
  - **Text Model Keep-Alive**: Keep the text model loaded in memory (-1 for indefinite)
 
 Click Submit to save. You can add multiple Ollama Vision configurations (each with a different name or model) if you wish; each configuration will appear as a device with its own sensors.
+
+**Note for existing installations**: If you have existing configurations with separate host and port fields, they will be automatically migrated to the `hostname:port` format when you edit them in the options flow.
 
 ## Usage
 

--- a/custom_components/ollama_vision/__init__.py
+++ b/custom_components/ollama_vision/__init__.py
@@ -68,6 +68,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Ollama Vision from a config entry."""
     host = entry.data.get(CONF_HOST) or entry.options.get(CONF_HOST)
     port = entry.data.get(CONF_PORT) or entry.options.get(CONF_PORT)
+    
+    # Migrate old config: combine host:port if port exists separately
+    if port and host and ':' not in host and not host.startswith('http'):
+        host = f"{host}:{port}"
+        port = None
+    
     model = entry.data.get(CONF_MODEL) or entry.options.get(CONF_MODEL)
     name = entry.data.get(CONF_NAME)
     vision_keepalive = entry.data.get(CONF_VISION_KEEPALIVE) or entry.options.get(CONF_VISION_KEEPALIVE, DEFAULT_KEEPALIVE)
@@ -84,7 +90,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     
     if text_model_enabled:
         text_host = entry.data.get(CONF_TEXT_HOST) or entry.options.get(CONF_TEXT_HOST)
-        text_port = entry.data.get(CONF_TEXT_PORT) or entry.options.get(CONF_TEXT_PORT, DEFAULT_TEXT_PORT)
+        text_port = entry.data.get(CONF_TEXT_PORT) or entry.options.get(CONF_TEXT_PORT)
+        
+        # Migrate old text config: combine host:port if port exists separately
+        if text_port and text_host and ':' not in text_host and not text_host.startswith('http'):
+            text_host = f"{text_host}:{text_port}"
+            text_port = None
+        
         text_model = entry.data.get(CONF_TEXT_MODEL) or entry.options.get(CONF_TEXT_MODEL, DEFAULT_TEXT_MODEL)
         text_keepalive = entry.data.get(CONF_TEXT_KEEPALIVE) or entry.options.get(CONF_TEXT_KEEPALIVE, DEFAULT_KEEPALIVE)
     
@@ -95,13 +107,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "client": client,
         "sensors": {},
         "config": {
-            CONF_HOST: host,
-            CONF_PORT: port,
+            CONF_HOST: host,  # host may contain hostname:port or full URL
             CONF_MODEL: model,
             CONF_NAME: name,
             CONF_TEXT_MODEL_ENABLED: text_model_enabled,
-            CONF_TEXT_HOST: text_host,
-            CONF_TEXT_PORT: text_port,
+            CONF_TEXT_HOST: text_host,  # host may contain hostname:port or full URL
             CONF_TEXT_MODEL: text_model,
             CONF_TEXT_KEEPALIVE: text_keepalive
         },

--- a/custom_components/ollama_vision/api.py
+++ b/custom_components/ollama_vision/api.py
@@ -5,8 +5,76 @@ import logging
 import aiohttp
 import base64
 import json
+from urllib.parse import urlparse
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _parse_url_or_host_port(url_or_host, port=None):
+    """
+    Parse either a full URL (e.g., http://server.example.com/subpath), hostname:port, or hostname.
+    
+    Returns a tuple of (protocol, host, port, path) where:
+    - protocol: 'http' or 'https'
+    - host: hostname or IP
+    - port: port number (int)
+    - path: path component (e.g., '/subpath') or empty string
+    
+    Supported formats:
+    - Full URL: http://server.example.com/subpath
+    - Hostname with port: 192.168.1.1:11434
+    - Hostname only: 192.168.1.1 (defaults to port 11434)
+    
+    If url_or_host is a full URL, port parameter is ignored.
+    If url_or_host contains hostname:port, port parameter is ignored.
+    """
+    url_or_host_str = str(url_or_host).strip()
+    
+    # Check if it looks like a full URL
+    if url_or_host_str.startswith("http://") or url_or_host_str.startswith("https://"):
+        try:
+            parsed = urlparse(url_or_host_str)
+            protocol = parsed.scheme
+            host = parsed.hostname
+            parsed_port = parsed.port
+            
+            # Default ports based on protocol
+            if parsed_port is None:
+                if protocol == "https":
+                    parsed_port = 443
+                else:
+                    parsed_port = 80
+            
+            path = parsed.path.rstrip('/')  # Remove trailing slash if present
+            
+            return protocol, host, parsed_port, path
+        except Exception as e:
+            _LOGGER.warning(f"Failed to parse URL '{url_or_host_str}': {e}. Treating as hostname.")
+            # Fall through to hostname handling
+    
+    # Check if it's in hostname:port format
+    if ':' in url_or_host_str and not url_or_host_str.startswith('http'):
+        try:
+            # Split on the last colon to handle IPv6 addresses
+            parts = url_or_host_str.rsplit(':', 1)
+            if len(parts) == 2:
+                host_part = parts[0]
+                port_part = parts[1]
+                # Try to parse port
+                try:
+                    parsed_port = int(port_part)
+                    return "http", host_part, parsed_port, ""
+                except ValueError:
+                    # Not a valid port, treat as hostname with colons (IPv6)
+                    pass
+        except Exception:
+            pass
+    
+    # Treat as hostname only (backward compatibility)
+    # Use provided port or default to 11434 (Ollama default)
+    parsed_port = port if port is not None else 11434
+    
+    return "http", url_or_host_str, int(parsed_port), ""
 
 
 class OllamaClient:
@@ -25,20 +93,33 @@ class OllamaClient:
         text_keepalive=-1,
     ):
         self.hass = hass
-        self.host = host
-        self.port = port
         self.model = model
         self.vision_keepalive = vision_keepalive
-        self.api_base_url = f"http://{host}:{port}/api"
+        
+        # Parse vision host/URL
+        vision_protocol, vision_host, vision_port, vision_path = _parse_url_or_host_port(host, port)
+        self.host = vision_host
+        self.port = vision_port
+        # Build API base URL with path support
+        base_path = vision_path if vision_path else ""
+        self.api_base_url = f"{vision_protocol}://{vision_host}:{vision_port}{base_path}/api"
 
+        # Parse text model host/URL
         self.text_enabled = text_host is not None
         self.text_host = text_host
         self.text_port = text_port
         self.text_model = text_model
         self.text_keepalive = text_keepalive
-        self.text_api_base_url = (
-            f"http://{text_host}:{text_port}/api" if self.text_enabled else None
-        )
+        
+        if self.text_enabled:
+            text_protocol, parsed_text_host, parsed_text_port, text_path = _parse_url_or_host_port(text_host, text_port)
+            self.text_host = parsed_text_host
+            self.text_port = parsed_text_port
+            # Build text API base URL with path support
+            text_base_path = text_path if text_path else ""
+            self.text_api_base_url = f"{text_protocol}://{parsed_text_host}:{parsed_text_port}{text_base_path}/api"
+        else:
+            self.text_api_base_url = None
 
     async def analyze_image(self, image_url: str, prompt: str) -> str:
         """


### PR DESCRIPTION
Allow entering a full URL for the Vision and Text model hosts. Check out the README for detailed options.