### PR TITLE
Fix reconfiguration persistence

### DIFF
--- a/custom_components/ollama_vision/__init__.py
+++ b/custom_components/ollama_vision/__init__.py
@@ -66,17 +66,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Ollama Vision from a config entry."""
-    host = entry.data.get(CONF_HOST) or entry.options.get(CONF_HOST)
-    port = entry.data.get(CONF_PORT) or entry.options.get(CONF_PORT)
+    host = entry.options.get(CONF_HOST) or entry.data.get(CONF_HOST)
+    port = entry.options.get(CONF_PORT) or entry.data.get(CONF_PORT)
     
     # Migrate old config: combine host:port if port exists separately
     if port and host and ':' not in host and not host.startswith('http'):
         host = f"{host}:{port}"
         port = None
     
-    model = entry.data.get(CONF_MODEL) or entry.options.get(CONF_MODEL)
+    model = entry.options.get(CONF_MODEL) or entry.data.get(CONF_MODEL)
     name = entry.data.get(CONF_NAME)
-    vision_keepalive = entry.data.get(CONF_VISION_KEEPALIVE) or entry.options.get(CONF_VISION_KEEPALIVE, DEFAULT_KEEPALIVE)
+    vision_keepalive = entry.options.get(CONF_VISION_KEEPALIVE) or entry.data.get(CONF_VISION_KEEPALIVE, DEFAULT_KEEPALIVE)
     
     # Get text model settings
     text_model_enabled = entry.options.get(
@@ -89,16 +89,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     text_keepalive = DEFAULT_KEEPALIVE
     
     if text_model_enabled:
-        text_host = entry.data.get(CONF_TEXT_HOST) or entry.options.get(CONF_TEXT_HOST)
-        text_port = entry.data.get(CONF_TEXT_PORT) or entry.options.get(CONF_TEXT_PORT)
+        text_host = entry.options.get(CONF_TEXT_HOST) or entry.data.get(CONF_TEXT_HOST)
+        text_port = entry.options.get(CONF_TEXT_PORT) or entry.data.get(CONF_TEXT_PORT)
         
         # Migrate old text config: combine host:port if port exists separately
         if text_port and text_host and ':' not in text_host and not text_host.startswith('http'):
             text_host = f"{text_host}:{text_port}"
             text_port = None
         
-        text_model = entry.data.get(CONF_TEXT_MODEL) or entry.options.get(CONF_TEXT_MODEL, DEFAULT_TEXT_MODEL)
-        text_keepalive = entry.data.get(CONF_TEXT_KEEPALIVE) or entry.options.get(CONF_TEXT_KEEPALIVE, DEFAULT_KEEPALIVE)
+        text_model = entry.options.get(CONF_TEXT_MODEL) or entry.data.get(CONF_TEXT_MODEL, DEFAULT_TEXT_MODEL)
+        text_keepalive = entry.options.get(CONF_TEXT_KEEPALIVE) or entry.data.get(CONF_TEXT_KEEPALIVE, DEFAULT_KEEPALIVE)
     
     client = OllamaClient(hass, host, port, model, text_host, text_port, text_model, vision_keepalive, text_keepalive)
     

--- a/custom_components/ollama_vision/config_flow.py
+++ b/custom_components/ollama_vision/config_flow.py
@@ -215,21 +215,35 @@ class OllamaVisionOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         # This will hold the vision configuration options from the first step
         self.vision_options = {}
 
     async def async_step_init(self, user_input=None):
         """Handle the first step: vision options and text model toggle."""
+        errors = {}
         if user_input is not None:
-            self.vision_options = user_input
-            if user_input.get(CONF_TEXT_MODEL_ENABLED):
-                # If text model is enabled, proceed to second step.
-                return await self.async_step_text_model_options()
-            return self.async_create_entry(title="", data=user_input)
+            try:
+                session = aiohttp.ClientSession()
+                api_url = _build_api_url(user_input[CONF_HOST], None, "version")
+                async with session.get(api_url) as response:
+                    if response.status == 200:
+                        await session.close()
+                        self.vision_options = user_input
+                        if user_input.get(CONF_TEXT_MODEL_ENABLED):
+                            # If text model is enabled, proceed to second step.
+                            return await self.async_step_text_model_options()
+                        return self.async_create_entry(title="", data=user_input)
+                    errors["base"] = "cannot_connect"
+                await session.close()
+            except aiohttp.ClientError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
 
-        options = self.config_entry.options
-        data = self.config_entry.data
+        options = self._config_entry.options
+        data = self._config_entry.data
         
         # Migrate old config: combine host:port if port exists separately
         existing_host = options.get(CONF_HOST, data.get(CONF_HOST, ""))
@@ -259,17 +273,32 @@ class OllamaVisionOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=schema,
+            errors=errors,
         )
 
     async def async_step_text_model_options(self, user_input=None):
         """Handle the second step: text model configuration options."""
+        errors = {}
         if user_input is not None:
-            # Merge the vision options and the text model options into one entry.
-            combined_options = {**self.vision_options, **user_input}
-            return self.async_create_entry(title="", data=combined_options)
+            try:
+                session = aiohttp.ClientSession()
+                api_url = _build_api_url(user_input[CONF_TEXT_HOST], None, "version")
+                async with session.get(api_url) as response:
+                    if response.status == 200:
+                        await session.close()
+                        # Merge the vision options and the text model options into one entry.
+                        combined_options = {**self.vision_options, **user_input}
+                        return self.async_create_entry(title="", data=combined_options)
+                    errors["base"] = "cannot_connect"
+                await session.close()
+            except aiohttp.ClientError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
 
-        options = self.config_entry.options
-        data = self.config_entry.data
+        options = self._config_entry.options
+        data = self._config_entry.data
         
         # Migrate old config: combine host:port if port exists separately
         existing_text_host = options.get(CONF_TEXT_HOST, data.get(CONF_TEXT_HOST, ""))
@@ -295,4 +324,5 @@ class OllamaVisionOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="text_model_options",
             data_schema=schema,
+            errors=errors,
         )

--- a/custom_components/ollama_vision/config_flow.py
+++ b/custom_components/ollama_vision/config_flow.py
@@ -207,15 +207,15 @@ class OllamaVisionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OllamaVisionOptionsFlow()
+        return OllamaVisionOptionsFlow(config_entry)
 
 
 class OllamaVisionOptionsFlow(config_entries.OptionsFlow):
     """Handle an options flow for Ollama Vision using multiple steps."""
 
-    def __init__(self):
+    def __init__(self, config_entry):
         """Initialize options flow."""
-        super().__init__()
+        self.config_entry = config_entry
         # This will hold the vision configuration options from the first step
         self.vision_options = {}
 

--- a/custom_components/ollama_vision/translations/en.json
+++ b/custom_components/ollama_vision/translations/en.json
@@ -56,7 +56,12 @@
             "text_keepalive": "Text Model Keep-Alive (-1 for indefinite)"
             }
         }
-        }
+        },
+      "error": {
+        "cannot_connect": "Cannot connect to Ollama",
+        "unknown": "Unexpected error occurred",
+        "required": "This field is required"
+      }
     },
     "services": {
       "analyze_image": {

--- a/custom_components/ollama_vision/translations/nb.json
+++ b/custom_components/ollama_vision/translations/nb.json
@@ -56,7 +56,12 @@
             "text_keepalive": "Tekstmodell keep-alive (-1 for alltid på)"
             }
         }
-        }
+        },
+      "error": {
+        "cannot_connect": "Kan ikke koble til Ollama",
+        "unknown": "En uventet feil oppstod",
+        "required": "Dette feltet er påkrevd"
+      }
     },
     "services": {
       "analyze_image": {

--- a/custom_components/ollama_vision/translations/pt.json
+++ b/custom_components/ollama_vision/translations/pt.json
@@ -56,7 +56,12 @@
             "text_keepalive": "Keep-Alive do Modelo de Texto (-1 para sempre ligado)"
             }
         }
-        }
+        },
+      "error": {
+        "cannot_connect": "Não é possível conectar ao Ollama",
+        "unknown": "Ocorreu um erro inesperado",
+        "required": "Este campo é obrigatório"
+      }
     },
     "services": {
       "analyze_image": {


### PR DESCRIPTION
Reconfiguration of a sensor only stored the new config. Now also persisting reconfiguration options to sensors. Also added host validation at the reconfiguration step and added some new translated error messages for the reconfiguration step.